### PR TITLE
Adding page-object find function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ D2L.Dom.Visibility.isVisible(element);
 D2L.Id.getUniqueId();
 ```
 
+**D2L.PageObject**
+
+```javascript
+// finds an object on the page
+D2L.PageObject.find('Some.Object');
+```
+
 ### Usage in Production
 
 In production, it's recommended to use a build tool like [Vulcanize](https://github.com/Polymer/vulcanize) to combine all your web components into a single import file. [More from the Polymer Docs: Optimize for Production](https://www.polymer-project.org/1.0/tools/optimize-for-production.html)...

--- a/d2l-page-object.html
+++ b/d2l-page-object.html
@@ -1,0 +1,29 @@
+<script>
+(function() {
+	'use strict';
+
+	var PageObject = {
+
+		find: function(name) {
+
+			var parts = name.split('.');
+			var func = window;
+
+			for (var i = 0; i < parts.length; i++) {
+				func = func[parts[i]];
+				if (!func) {
+					break;
+				}
+			}
+
+			return func;
+
+		}
+
+	};
+
+	window.D2L = window.D2L || {};
+	window.D2L.PageObject = PageObject;
+
+})();
+</script>

--- a/test/page-object.html
+++ b/test/page-object.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>d2l-id tests</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../d2l-page-object.html">
+	</head>
+	<body>
+
+		<script>
+
+			describe('d2l-page-object', function() {
+
+				describe('find', function() {
+
+					beforeEach(function() {
+						window.PageObject = {
+							SomeObject: {
+								SomeFunction: function() {
+									return 'some value';
+								}
+							}
+						}
+					});
+
+					it('finds object on page', function() {
+						var someObject = D2L.PageObject.find('PageObject.SomeObject');
+						expect(someObject).not.to.be.null;
+						expect(someObject.SomeFunction()).to.equal('some value');
+					});
+
+				});
+
+			});
+
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
@dlockhart : this utility function is copied from (and intends to replace) the `FindPageObjectBehavior` defined [in Nav](https://github.com/Brightspace/d2l-navigation-ui/blob/master/find-page-object-behavior.html) since it's not really WC behavior.  I am curious of the original rationale of this method? (for example, why not just call `D2L.LP.Web.UI.Html.PartialRendering.PartialRender`, etc.)?

This function is imported/used by:

```
<link rel="import" href="../d2l-page-object.html">
<script>
     D2L.PageObject.find('PageObject.SomeObject');
</script>
```

I've already added `D2L.Id.getUniqueId`.  We can change the name if need-be... I haven't released a new version of this lib but planning to once this PR is merged/deleted, and will switch Nav over to use it.
