### PR TITLE
Get focusable ancestor/get non-navigable focusable nodes

### DIFF
--- a/d2l-dom-focus.html
+++ b/d2l-dom-focus.html
@@ -205,6 +205,10 @@
 				includeHidden = false;
 			}
 
+			if (includeTabbablesOnly === undefined) {
+				includeTabbablesOnly = true;
+			}
+
 			var parentNode = D2L.Dom.getComposedParent(node);
 
 			while (parentNode) {

--- a/d2l-dom-focus.html
+++ b/d2l-dom-focus.html
@@ -195,19 +195,49 @@
 
 		},
 
-		isFocusable: function(node, includeHidden) {
+		getPreviousFocusableAncestor: function(node, includeHidden, includeTabbablesOnly) {
+
+			if (!node) {
+				return null;
+			}
+
+			if (includeHidden === undefined) {
+				includeHidden = false;
+			}
+
+			var parentNode = D2L.Dom.getComposedParent(node);
+
+			while (parentNode) {
+
+				if (this.isFocusable(parentNode, includeHidden, includeTabbablesOnly)) {
+					return parentNode;
+				}
+
+				parentNode = D2L.Dom.getComposedParent(parentNode);
+			}
+
+			return null;
+
+		},
+
+		isFocusable: function(node, includeHidden, includeTabbablesOnly) {
 
 			if (!node || node.nodeType !== 1 || node.disabled) {
 				return false;
 			}
 
+			if (includeTabbablesOnly === undefined) {
+				includeTabbablesOnly = true;
+			}
+
 			var _isFocusable;
+			var _minTabIndex = includeTabbablesOnly ? 0 : -1;
 
 			// IE treats all nodes without tabindex explicitly set as having tabindex=0
 			if (node.getAttributeNode) {
 				var tabIndexAttr = node.getAttributeNode('tabindex');
 				if (tabIndexAttr && tabIndexAttr.specified) {
-					_isFocusable = (tabIndexAttr.value >= 0);
+					_isFocusable = (tabIndexAttr.value >= _minTabIndex);
 				}
 			}
 

--- a/test/dom-focus.html
+++ b/test/dom-focus.html
@@ -86,10 +86,12 @@
 		<test-fixture id="focusableFixture">
 			<template>
 				<div>
-					<a></a>
-					<button></button>
-					some text node
-					<!-- some comment node -->
+					<div id="optionallyFocusable">
+						<a></a>
+						<button></button>
+						some text node
+						<!-- some comment node -->
+					</div>
 				</div>
 			</template>
 		</test-fixture>
@@ -241,9 +243,19 @@
 					expect(D2L.Dom.Focus.isFocusable(focusableFixture.querySelector('a'))).to.be.true;
 				});
 
-				it('returns false if tabindex=-1', function() {
+				it('returns false if tabindex=-1 and includeTabbablesOnly is undefined', function() {
 					focusableFixture.querySelector('a').setAttribute('tabindex', '-1');
 					expect(D2L.Dom.Focus.isFocusable(focusableFixture.querySelector('a'))).to.be.false;
+				});
+
+				it('returns false if tabindex=-1 and includeTabbablesOnly is true', function() {
+					focusableFixture.querySelector('a').setAttribute('tabindex', '-1');
+					expect(D2L.Dom.Focus.isFocusable(focusableFixture.querySelector('a'), null, true)).to.be.false;
+				});
+
+				it('returns true if tabindex=-1 and includedTabbablesOnly is false', function() {
+					focusableFixture.querySelector('a').setAttribute('tabindex', '-1');
+					expect(D2L.Dom.Focus.isFocusable(focusableFixture.querySelector('a'), null, false)).to.be.true;
 				});
 
 				it('returns false if not displayed', function() {
@@ -282,6 +294,29 @@
 				it('returns false for comment node', function() {
 					var commentNode = focusableFixture.querySelector('button').nextSibling.nextSibling;
 					expect(D2L.Dom.Focus.isFocusable(commentNode)).to.be.false;
+				});
+
+			});
+
+			describe('getPreviousFocusableAncestor', function() {
+
+				var focusableFixture;
+
+				beforeEach(function() {
+					focusableFixture = fixture('focusableFixture');
+				});
+
+				it('returns focusable div', function() {
+					var focusableDiv = focusableFixture.querySelector('#optionallyFocusable');
+
+					focusableDiv.setAttribute('tabindex', '-1');
+					expect(D2L.Dom.Focus.getPreviousFocusableAncestor(focusableFixture.querySelector('a'), false, false))
+						.to.equal(focusableDiv);
+				});
+
+				it('returns body when no ancestor focusable', function() {
+					expect(D2L.Dom.Focus.getPreviousFocusableAncestor(focusableFixture.querySelector('a'), false, false))
+						.to.equal(document.body);
 				});
 
 			});


### PR DESCRIPTION
Adds function `getPreviousFocusableAncestor` which returns the nearest focusable ancestor of a given node.

Updates `isFocusable` to optionally return `true` if a node is focusable, but not keyboard navigable (ie, `tabindex="-1"`. 
