### PR TITLE
Support non-Node elements

### DIFF
--- a/d2l-dom.html
+++ b/d2l-dom.html
@@ -31,7 +31,7 @@
 				if (node.shadowRoot) {
 					node = node.shadowRoot;
 				}
-				nodes = node.children || {};
+				nodes = node.children || node.childNodes;
 			}
 
 			for (var i = 0; i < nodes.length; i++) {

--- a/d2l-dom.html
+++ b/d2l-dom.html
@@ -31,7 +31,7 @@
 				if (node.shadowRoot) {
 					node = node.shadowRoot;
 				}
-				nodes = node.children;
+				nodes = node.children || {};
 			}
 
 			for (var i = 0; i < nodes.length; i++) {


### PR DESCRIPTION
This was found to be a problem in: DE24075
Internet Explorer would use SVGElements, which would fail when trying to `getComposedChildren`
since `node` then wouldn't have `.children`