### PR TITLE
Adding basic global z-index manager.

### DIFF
--- a/d2l-zindex.html
+++ b/d2l-zindex.html
@@ -1,0 +1,26 @@
+<script>
+(function() {
+	'use strict';
+
+	var ZIndex = {
+
+		_zIndex: 0,
+
+		getZIndex: function(minZIndex) {
+
+			this._zIndex += 1;
+			if (minZIndex && this._zIndex < minZIndex) {
+				this._zIndex = minZIndex;
+			}
+
+			return this._zIndex;
+
+		}
+
+	};
+
+	window.D2L = window.D2L || {};
+	window.D2L.ZIndex = ZIndex;
+
+})();
+</script>

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,8 @@
 			'dom-visibility.html?dom-shadow',
 			'dom-focus.html?wc-shadydom',
 			'dom-focus.html?dom=shadow',
-			'id.html'
+			'id.html',
+			'zindex.html'
 		]);
 		</script>
 	</body>

--- a/test/zindex.html
+++ b/test/zindex.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>d2l-zindex tests</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../d2l-zindex.html">
+	</head>
+	<body>
+
+		<script>
+
+			describe('d2l-zindex', function() {
+
+				describe('getZIndex', function() {
+
+					beforeEach(function() {
+						D2L.ZIndex._zIndex = 0;
+					});
+
+					it('gets a larger value each time called', function() {
+						expect(D2L.ZIndex.getZIndex()).not.to.equal(D2L.ZIndex.getZIndex());
+					});
+
+					it('gets the specified minimum z-index value if it is larger than the current', function() {
+						expect(D2L.ZIndex.getZIndex(1000)).to.equal(1000);
+					});
+
+					it('gets the calculated z-index value if it is larger than the specified minimum', function() {
+						D2L.ZIndex.getZIndex(500);
+						expect(D2L.ZIndex.getZIndex(100)).to.equal(501);
+					});
+
+				});
+
+			});
+
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
This PR adds a simple z-index helper for the root.  The `getZIndex` method will return a new z-index value that is greater than the last (i.e. z-index to put layer on top).  I provided the ability to pass a min value, which I will use in LMS code to minimize risk associated with changing current z-index values (PRs for LP and Navbars coming).

