### PR TITLE
Dbatiste/swipe gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ D2L.Dom.Focus.isFocusable(element);
 D2L.Dom.Visibility.isVisible(element);
 ```
 
+**D2L.Gestures.Swipe**
+
+```javascript
+// sets up event listeners for swipe gesture
+D2L.Gestures.Swipe.register(element);
+
+// listen for custom swipe event
+element.addEventListener('d2l-swipe', function (e) {
+	console.log(
+		e.detail.distance,  // .x/.y
+		e.detail.direction, // deg
+		e.detail.duration   // ms
+	);
+}.bind(this));
+
+// unregister event listeners for swipe gesture
+D2L.Gestures.Swipe.unregister(element);
+```
+
 **D2L.Id**
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ D2L.Gestures.Swipe.register(element);
 // listen for custom swipe event
 element.addEventListener('d2l-swipe', function (e) {
 	console.log(
-		e.detail.distance,  // .x/.y
-		e.detail.direction, // deg
-		e.detail.duration   // ms
+		e.detail.distance,             // .x/.y
+		e.detail.direction.angle,      // deg
+		e.detail.direction.horizontal, // left/right
+		e.detail.direction.vertical,   // up/down
+		e.detail.duration              // ms
 	);
 }.bind(this));
 

--- a/d2l-gestures-swipe.html
+++ b/d2l-gestures-swipe.html
@@ -57,9 +57,6 @@
 					theta = ((2 * Math.PI) - theta) * 57.3;
 				}
 
-				var hasVerticalDistance = (Math.abs(distanceY) >= window.D2L.Gestures.Swipe._minDistance);
-				var hasHorizontalDistance = (Math.abs(distanceX) >= window.D2L.Gestures.Swipe._minDistance);
-
 				var horizontal = 'none';
 				if (Math.abs(distanceX) >= window.D2L.Gestures.Swipe._minDistance) {
 					if (theta > 205 && theta < 335) {

--- a/d2l-gestures-swipe.html
+++ b/d2l-gestures-swipe.html
@@ -22,6 +22,12 @@
 				tracking = null;
 				node.removeEventListener('touchend', handleTouchEnd);
 				node.removeEventListener('touchermove', handleTouchMove);
+				node.removeEventListener('touchcancel', handleTouchCancel);
+			};
+
+			var handleTouchCancel = function(e) {
+				reset();
+				return;
 			};
 
 			var handleTouchEnd = function(e) {
@@ -77,6 +83,7 @@
 
 			node.addEventListener('touchend', handleTouchEnd);
 			node.addEventListener('touchmove', handleTouchMove);
+			node.addEventListener('touchcancel', handleTouchCancel);
 
 		},
 

--- a/d2l-gestures-swipe.html
+++ b/d2l-gestures-swipe.html
@@ -6,7 +6,7 @@
 
 		_maxTime: 2000,
 
-		_handleTouchStart: function (e) {
+		_handleTouchStart: function(e) {
 
 			var node = this;
 
@@ -18,19 +18,19 @@
 				}
 			};
 
-			var reset = function () {
+			var reset = function() {
 				tracking = null;
 				node.removeEventListener('touchend', handleTouchEnd);
 				node.removeEventListener('touchermove', handleTouchMove);
 				node.removeEventListener('touchcancel', handleTouchCancel);
 			};
 
-			var handleTouchCancel = function(e) {
+			var handleTouchCancel = function() {
 				reset();
 				return;
 			};
 
-			var handleTouchEnd = function(e) {
+			var handleTouchEnd = function() {
 
 				if (!tracking || !tracking.end) {
 					return;
@@ -70,7 +70,7 @@
 				reset();
 			};
 
-			var handleTouchMove = function (e) {
+			var handleTouchMove = function(e) {
 				if (!tracking) {
 					return;
 				}
@@ -87,11 +87,11 @@
 
 		},
 
-		register: function (node) {
+		register: function(node) {
 			node.addEventListener('touchstart', this._handleTouchStart);
 		},
 
-		unregister: function (node) {
+		unregister: function(node) {
 			node.removeEventListener('touchstart', this._handleTouchStart);
 		}
 

--- a/d2l-gestures-swipe.html
+++ b/d2l-gestures-swipe.html
@@ -60,6 +60,24 @@
 				var hasVerticalDistance = (Math.abs(distanceY) >= window.D2L.Gestures.Swipe._minDistance);
 				var hasHorizontalDistance = (Math.abs(distanceX) >= window.D2L.Gestures.Swipe._minDistance);
 
+				var horizontal = 'none';
+				if (Math.abs(distanceX) >= window.D2L.Gestures.Swipe._minDistance) {
+					if (theta > 205 && theta < 335) {
+						horizontal = 'left';
+					} else if (theta > 25 && theta < 155) {
+						horizontal = 'right';
+					}
+				}
+
+				var vertical = 'none';
+				if (Math.abs(distanceY) >= window.D2L.Gestures.Swipe._minDistance) {
+					if (theta > 295 || theta < 65) {
+						vertical = 'up';
+					} else if (theta > 115 && theta < 245) {
+						vertical = 'down';
+					}
+				}
+
 				node.dispatchEvent(new CustomEvent('d2l-swipe', {
 					detail: {
 						distance: {
@@ -68,10 +86,8 @@
 						},
 						direction: {
 							angle: theta,
-							isUp: (hasVerticalDistance && (theta > 295 || theta < 65)),
-							isDown: (hasVerticalDistance && (theta > 115 && theta < 245)),
-							isLeft: (hasHorizontalDistance && (theta > 205 && theta < 335)),
-							isRight: (hasHorizontalDistance && (theta > 25 && theta < 155))
+							horizontal: horizontal,
+							vertical: vertical
 						},
 						duration: elapsedTime
 					}

--- a/d2l-gestures-swipe.html
+++ b/d2l-gestures-swipe.html
@@ -5,6 +5,7 @@
 	var Swipe = {
 
 		_maxTime: 2000,
+		_minDistance: 30,
 
 		_handleTouchStart: function(e) {
 
@@ -56,13 +57,22 @@
 					theta = ((2 * Math.PI) - theta) * 57.3;
 				}
 
+				var hasVerticalDistance = (Math.abs(distanceY) >= window.D2L.Gestures.Swipe._minDistance);
+				var hasHorizontalDistance = (Math.abs(distanceX) >= window.D2L.Gestures.Swipe._minDistance);
+
 				node.dispatchEvent(new CustomEvent('d2l-swipe', {
 					detail: {
 						distance: {
 							x: distanceX,
 							y: distanceY
 						},
-						direction: theta,
+						direction: {
+							angle: theta,
+							isUp: (hasVerticalDistance && (theta > 295 || theta < 65)),
+							isDown: (hasVerticalDistance && (theta > 115 && theta < 245)),
+							isLeft: (hasHorizontalDistance && (theta > 205 && theta < 335)),
+							isRight: (hasHorizontalDistance && (theta > 25 && theta < 155))
+						},
 						duration: elapsedTime
 					}
 				}));

--- a/d2l-gestures-swipe.html
+++ b/d2l-gestures-swipe.html
@@ -1,0 +1,98 @@
+<script>
+(function() {
+	'use strict';
+
+	var Swipe = {
+
+		_maxTime: 2000,
+
+		_handleTouchStart: function (e) {
+
+			var node = this;
+
+			var tracking = {
+				start: {
+					time: new Date().getTime(),
+					x: e.touches[0].clientX,
+					y: e.touches[0].clientY
+				}
+			};
+
+			var reset = function () {
+				tracking = null;
+				node.removeEventListener('touchend', handleTouchEnd);
+				node.removeEventListener('touchermove', handleTouchMove);
+			};
+
+			var handleTouchEnd = function(e) {
+
+				if (!tracking || !tracking.end) {
+					return;
+				}
+
+				var elapsedTime = new Date().getTime() - tracking.start.time;
+				if (elapsedTime > window.D2L.Gestures.Swipe._maxTime) {
+					reset();
+					return;
+				}
+
+				var distanceX = tracking.end.x - tracking.start.x;
+				var distanceY = tracking.end.y - tracking.start.y;
+
+				var theta = Math.atan(Math.abs(distanceX) / Math.abs(distanceY));
+				if (distanceY > 0 && distanceX > 0) {
+					theta = (Math.PI - theta) * 57.3;
+				} else if (distanceY > 0 && distanceX < 0) {
+					theta = (Math.PI + theta) * 57.3;
+				} else if (distanceY < 0 && distanceX > 0) {
+					theta = theta * 57.3;
+				} else if (distanceY < 0 && distanceX < 0) {
+					theta = ((2 * Math.PI) - theta) * 57.3;
+				}
+
+				node.dispatchEvent(new CustomEvent('d2l-swipe', {
+					detail: {
+						distance: {
+							x: distanceX,
+							y: distanceY
+						},
+						direction: theta,
+						duration: elapsedTime
+					}
+				}));
+
+				reset();
+			};
+
+			var handleTouchMove = function (e) {
+				if (!tracking) {
+					return;
+				}
+				e.preventDefault();
+				tracking.end = {
+					x: e.touches[0].clientX,
+					y: e.touches[0].clientY
+				};
+			};
+
+			node.addEventListener('touchend', handleTouchEnd);
+			node.addEventListener('touchmove', handleTouchMove);
+
+		},
+
+		register: function (node) {
+			node.addEventListener('touchstart', this._handleTouchStart);
+		},
+
+		unregister: function (node) {
+			node.removeEventListener('touchstart', this._handleTouchStart);
+		}
+
+	};
+
+	window.D2L = window.D2L || {};
+	window.D2L.Gestures = window.D2L.Gestures || {};
+	window.D2L.Gestures.Swipe = Swipe;
+
+})();
+</script>


### PR DESCRIPTION
Adds basic swipe gesture logic by wrapping browser touch events.  Exposes `d2l-swipe` event with swipe info such as distance swipes (`x` and `y`), direction, and duration of the swipe.