### PR TITLE
Dbatiste/visible on ancestor fix reattach

### DIFF
--- a/d2l-visible-on-ancestor-behavior.html
+++ b/d2l-visible-on-ancestor-behavior.html
@@ -40,7 +40,20 @@
 
 		},
 
+		attached: function() {
+			this.__voaAttached = true;
+			if (this.visibleOnAncestor) {
+				this.setAttribute('d2l-visible-on-ancestor-init', 'd2l-visible-on-ancestor-init');
+				this.__voaInit();
+			} else if (this.hasAttribute('d2l-visible-on-ancestor-hide')) {
+				fastdom.mutate(function() {
+					this.removeAttribute('d2l-visible-on-ancestor-hide');
+				}.bind(this));
+			}
+		},
+
 		detached: function() {
+			this.__voaAttached = false;
 			this.__voaUninit();
 		},
 
@@ -88,17 +101,16 @@
 		},
 
 		__voaHandleVisibleOnAncestor: function(newValue, oldValue) {
+			if (!this.__voaAttached) return;
 			if (oldValue === undefined && newValue) {
 				// this class prevents possible FOUC in slow clients
 				this.setAttribute('d2l-visible-on-ancestor-init', 'd2l-visible-on-ancestor-init');
 			}
-			requestAnimationFrame(function() {
-				if (newValue) {
-					this.__voaInit();
-				} else if (oldValue) {
-					this.__voaUninit();
-				}
-			}.bind(this));
+			if (newValue) {
+				this.__voaInit();
+			} else if (oldValue) {
+				this.__voaUninit();
+			}
 		},
 
 		__voaHide: function() {
@@ -112,35 +124,39 @@
 
 		__voaInit: function() {
 
-			if (!this.visibleOnAncestor) {
-				this.removeAttribute('d2l-visible-on-ancestor-init');
-				return;
-			}
+			requestAnimationFrame(function() {
 
-			this.__voaTarget = D2L.Dom.findComposedAncestor(this, function(node) {
-				if (!node || node.nodeType !== 1) return false;
-				return (node.classList.contains('d2l-visible-on-ancestor-target'));
-			});
-			if (!this.__voaTarget) {
-				this.removeAttribute('d2l-visible-on-ancestor-init');
-				return;
-			}
+				if (!this.visibleOnAncestor) {
+					this.removeAttribute('d2l-visible-on-ancestor-init');
+					return;
+				}
 
-			this.__voaHandleBlur = this.__voaHandleBlur.bind(this);
-			this.__voaHandleFocus = this.__voaHandleFocus.bind(this);
-			this.__voaHandleMouseEnter = this.__voaHandleMouseEnter.bind(this);
-			this.__voaHandleMouseLeave = this.__voaHandleMouseLeave.bind(this);
-			this.__voaHandleHideEnd = this.__voaHandleHideEnd.bind(this);
-			this.__voaHandleShowEnd = this.__voaHandleShowEnd.bind(this);
+				this.__voaTarget = D2L.Dom.findComposedAncestor(this, function(node) {
+					if (!node || node.nodeType !== 1) return false;
+					return (node.classList.contains('d2l-visible-on-ancestor-target'));
+				});
+				if (!this.__voaTarget) {
+					this.removeAttribute('d2l-visible-on-ancestor-init');
+					return;
+				}
 
-			this.__voaTarget.addEventListener('focus', this.__voaHandleFocus, true);
-			this.__voaTarget.addEventListener('blur', this.__voaHandleBlur, true);
-			this.__voaTarget.addEventListener('mouseenter', this.__voaHandleMouseEnter);
-			this.__voaTarget.addEventListener('mouseleave', this.__voaHandleMouseLeave);
+				this.__voaHandleBlur = this.__voaHandleBlur.bind(this);
+				this.__voaHandleFocus = this.__voaHandleFocus.bind(this);
+				this.__voaHandleMouseEnter = this.__voaHandleMouseEnter.bind(this);
+				this.__voaHandleMouseLeave = this.__voaHandleMouseLeave.bind(this);
+				this.__voaHandleHideEnd = this.__voaHandleHideEnd.bind(this);
+				this.__voaHandleShowEnd = this.__voaHandleShowEnd.bind(this);
 
-			fastdom.mutate(function() {
-				this.removeAttribute('d2l-visible-on-ancestor-init');
-				this.setAttribute('d2l-visible-on-ancestor-hide', 'd2l-visible-on-ancestor-hide');
+				this.__voaTarget.addEventListener('focus', this.__voaHandleFocus, true);
+				this.__voaTarget.addEventListener('blur', this.__voaHandleBlur, true);
+				this.__voaTarget.addEventListener('mouseenter', this.__voaHandleMouseEnter);
+				this.__voaTarget.addEventListener('mouseleave', this.__voaHandleMouseLeave);
+
+				fastdom.mutate(function() {
+					this.removeAttribute('d2l-visible-on-ancestor-init');
+					this.setAttribute('d2l-visible-on-ancestor-hide', 'd2l-visible-on-ancestor-hide');
+				}.bind(this));
+
 			}.bind(this));
 
 		},

--- a/d2l-visible-on-ancestor-behavior.html
+++ b/d2l-visible-on-ancestor-behavior.html
@@ -43,6 +43,7 @@
 		attached: function() {
 			this.__voaAttached = true;
 			if (this.visibleOnAncestor) {
+				// this class prevents possible FOUC in slow clients
 				this.setAttribute('d2l-visible-on-ancestor-init', 'd2l-visible-on-ancestor-init');
 				this.__voaInit();
 			} else if (this.hasAttribute('d2l-visible-on-ancestor-hide')) {

--- a/demo/visible-on-ancestor-behavior/d2l-visible-on-ancestor-component.html
+++ b/demo/visible-on-ancestor-behavior/d2l-visible-on-ancestor-component.html
@@ -4,7 +4,7 @@
 
 <dom-module id="d2l-visible-on-ancestor-component">
 	<template>
-		<style>
+		<style include="d2l-visible-on-ancestor-styles">
 			:host {
 				display: inline-block;
 			}

--- a/demo/visible-on-ancestor-behavior/index.html
+++ b/demo/visible-on-ancestor-behavior/index.html
@@ -9,6 +9,30 @@
 		d2l-visible-on-ancestor-component {
 			margin: 20px;
 		}
+		.ancestor-container {
+			background-color: rgba(0,0,0,0.03);
+			border: 1px dashed black;
+			display: inline-block;
+			padding: 1rem;
+			position: relative;
+			min-width: 240px;
+			min-height: 80px;
+		}
+		.ancestor-container::before {
+			box-sizing: border-box;
+			content: 'target 'attr(id);
+			font-size: 0.7rem;
+			height: 100%;
+			left:0;
+			padding: 0.5rem;
+			position: absolute;;
+			text-align: right;
+			top: 0;
+			width: 100%;
+		}
+		.ancestor-container.d2l-visible-on-ancestor-target::before {
+			content: 'target 'attr(id)'; visible-on-ancestor';
+		}
 	</style>
 </head>
 <body unresolved>
@@ -18,11 +42,41 @@
 	<h2>Component</h2>
 
 	<d2l-visible-on-ancestor-component id="wc1">focusable 1</d2l-visible-on-ancestor-component>
-	<div class="d2l-visible-on-ancestor-target" style="display: inline-block; border: 1px dashed black;">
-		<d2l-visible-on-ancestor-component id="wc2">focusable 2</d2l-visible-on-ancestor-component>
-		<d2l-visible-on-ancestor-component id="wc3" visible-on-ancestor>focusable 3</d2l-visible-on-ancestor-component>
+	<div id="target1" class="d2l-visible-on-ancestor-target ancestor-container">
+		<d2l-visible-on-ancestor-component id="wc2" visible-on-ancestor>focusable 2</d2l-visible-on-ancestor-component>
+		<d2l-visible-on-ancestor-component id="wc3" >focusable 3</d2l-visible-on-ancestor-component>
 	</div>
-	<d2l-visible-on-ancestor-component id="wc4">focusable 4</d2l-visible-on-ancestor-component>
 
+	<div id="target2" class="d2l-visible-on-ancestor-target ancestor-container">
+			<d2l-visible-on-ancestor-component id="wc4">focusable 4</d2l-visible-on-ancestor-component>
+	</div>
+
+	<div id="target3" class="ancestor-container">
+		<d2l-visible-on-ancestor-component id="wc5">focusable 5</d2l-visible-on-ancestor-component>
+	</div>
+
+	<div style="margin-top: 1rem;">
+		<button onclick="moveToTarget('target2');">move to target 2</button>
+		<button onclick="moveToTarget('target3');">move to target 3</button>
+	</div>
+
+	<script>
+		function moveToTarget(id) {
+
+			var wc = document.getElementById('wc2');
+			var parent = wc.parentNode;
+
+			wc.parentNode.removeChild(wc);
+
+			parent = document.getElementById(id);
+
+			if (!parent.classList.contains('d2l-visible-on-ancestor-target')) {
+				wc.removeAttribute('visible-on-ancestor');
+			}
+
+			parent.appendChild(wc);
+
+		}
+	</script>
 </body>
 </html>

--- a/test/visible-on-ancestor-behavior.html
+++ b/test/visible-on-ancestor-behavior.html
@@ -54,6 +54,17 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="multipleVisibleOnAncestor">
+			<template>
+				<div>
+					<div id="target1" class="d2l-visible-on-ancestor-target">
+						<d2l-visible-on-ancestor-behavior-test id="wc1" visible-on-ancestor>focusable 1</d2l-visible-on-ancestor-behavior-test>
+					</div>
+					<div id="target2" class="d2l-visible-on-ancestor-target"></div>
+				</div>
+			</template>
+		</test-fixture>
+
 		<script>
 
 		describe('d2l-visible-on-ancestor-behavior', function() {
@@ -124,7 +135,7 @@
 					expect(isDisplayed(voaFixture.querySelector('#wc2'))).to.equal(true);
 				});
 
-				it('is not visible if visible visible-on-ancestor attribute is specified', function(done) {
+				it('is not visible if visible-on-ancestor attribute is specified', function(done) {
 					requestAnimationFrame(function() {
 						expect(isDisplayed(voaFixture.querySelector('#wc3'))).to.equal(false);
 						done();
@@ -188,6 +199,79 @@
 							expect(isDisplayed(voaFixture.querySelector('#wc3'))).to.equal(false);
 							done();
 						});
+					});
+				});
+
+			});
+
+			describe('multiple visible-on-ancestor targets', function() {
+
+				beforeEach(function(done) {
+					voaFixture = fixture('multipleVisibleOnAncestor');
+					Polymer.RenderStatus.afterNextRender(voaFixture, done);
+				});
+
+				it('is not visible if visible-on-ancestor element is moved to another target', function(done) {
+					requestAnimationFrame(function() {
+						var elem = voaFixture.querySelector('#wc1');
+						expect(isDisplayed(elem)).to.equal(false);
+						elem.parentNode.removeChild(elem);
+						voaFixture.querySelector('#target2').appendChild(elem);
+						requestAnimationFrame(function() {
+							expect(isDisplayed(elem)).to.equal(false);
+							done();
+						}.bind(this));
+
+					});
+
+				});
+
+				it('is not visible when mouseenter fires on old target of transplanted visible-on-ancestor element', function(done) {
+					requestAnimationFrame(function() {
+						var elem = voaFixture.querySelector('#wc1');
+						elem.parentNode.removeChild(elem);
+						voaFixture.querySelector('#target2').appendChild(elem);
+						requestAnimationFrame(function() {
+							dispatchMouseEvent(voaFixture.querySelector('#target1'), 'mouseenter');
+							requestAnimationFrame(function() {
+								expect(isDisplayed(elem)).to.equal(false);
+								done();
+							});
+						}.bind(this));
+					});
+				});
+
+				it('is visible when mouseenter fires on new target of transplanted visible-on-ancestor element', function(done) {
+					requestAnimationFrame(function() {
+						var elem = voaFixture.querySelector('#wc1');
+						elem.parentNode.removeChild(elem);
+						voaFixture.querySelector('#target2').appendChild(elem);
+						requestAnimationFrame(function() {
+							dispatchMouseEvent(voaFixture.querySelector('#target2'), 'mouseenter');
+							requestAnimationFrame(function() {
+								expect(isDisplayed(elem)).to.equal(true);
+								done();
+							});
+						}.bind(this));
+					});
+				});
+
+				it('is not visible when mouseleave fires on new target of transplanted visible-on-ancestor element', function(done) {
+					requestAnimationFrame(function() {
+						var elem = voaFixture.querySelector('#wc1');
+						elem.parentNode.removeChild(elem);
+						voaFixture.querySelector('#target2').appendChild(elem);
+						requestAnimationFrame(function() {
+							dispatchMouseEvent(voaFixture.querySelector('#target2'), 'mouseenter');
+							requestAnimationFrame(function() {
+								expect(isDisplayed(elem)).to.equal(true);
+								dispatchMouseEvent(voaFixture.querySelector('#target2'), 'mouseleave');
+								requestAnimationFrame(function() {
+									expect(isDisplayed(elem)).to.equal(false);
+									done();
+								});
+							});
+						}.bind(this));
 					});
 				});
 


### PR DESCRIPTION
This PR fixes an oversight with init/uninit of the `visible-on-ancestor` behavior.  Specifically, the cases where the element is transplanted but the `visible-on-ancestor` attribute is not changing.  Additionally, the element being transplanted may have a the same, or new target.