### PR TITLE
Add nowrap and up-down-left-right directions options for arrowkeys-be…

### DIFF
--- a/d2l-focusable-arrowkeys-behavior.html
+++ b/d2l-focusable-arrowkeys-behavior.html
@@ -26,6 +26,11 @@
 			arrowKeyFocusablesDirection: {
 				type: String,
 				value: 'leftright'
+			},
+
+			arrowKeyFocusablesNoWrap: {
+				type: Boolean,
+				value: false
 			}
 
 		},
@@ -123,7 +128,7 @@
 
 		__handleKeyDown: function(e) {
 			var target = e.target;
-			if (this.arrowKeyFocusablesDirection === 'leftright' && e.keyCode === this.__keyCodes.LEFT) {
+			if (this.arrowKeyFocusablesDirection.indexOf('left') >= 0 && e.keyCode === this.__keyCodes.LEFT) {
 				fastdom.measure(function() {
 					if (getComputedStyle(this).direction === 'rtl') {
 						this.__focusNext(target);
@@ -131,7 +136,7 @@
 						this.__focusPrevious(target);
 					}
 				}.bind(this));
-			} else if (this.arrowKeyFocusablesDirection === 'leftright' && e.keyCode === this.__keyCodes.RIGHT) {
+			} else if (this.arrowKeyFocusablesDirection.indexOf('right') >= 0 && e.keyCode === this.__keyCodes.RIGHT) {
 				fastdom.measure(function() {
 					if (getComputedStyle(this).direction === 'rtl') {
 						this.__focusPrevious(target);
@@ -139,10 +144,10 @@
 						this.__focusNext(target);
 					}
 				}.bind(this));
-			} else if (this.arrowKeyFocusablesDirection === 'updown' && e.keyCode === this.__keyCodes.UP) {
-				this.__focusPrevious(e.target);
-			} else if (this.arrowKeyFocusablesDirection === 'updown' && e.keyCode === this.__keyCodes.DOWN) {
-				this.__focusNext(e.target);
+			} else if (this.arrowKeyFocusablesDirection.indexOf('up') >= 0 && e.keyCode === this.__keyCodes.UP) {
+				this.__focusPrevious(target);
+			} else if (this.arrowKeyFocusablesDirection.indexOf('down') >= 0 && e.keyCode === this.__keyCodes.DOWN) {
+				this.__focusNext(target);
 			} else if (e.keyCode === this.__keyCodes.HOME) {
 				this.__focusFirst();
 			} else if (e.keyCode === this.__keyCodes.END) {
@@ -159,6 +164,9 @@
 			}
 			var index = elems.indexOf(elem);
 			if (index === elems.length - 1) {
+				if (this.arrowKeyFocusablesNoWrap) {
+					return elem;
+				}
 				return elems[0];
 			}
 			return elems[index + 1];
@@ -170,6 +178,9 @@
 			}
 			var index = elems.indexOf(elem);
 			if (index === 0) {
+				if (this.arrowKeyFocusablesNoWrap) {
+					return elem;
+				}
 				return elems[elems.length - 1];
 			}
 			return elems[index - 1];

--- a/d2l-focusable-arrowkeys-behavior.html
+++ b/d2l-focusable-arrowkeys-behavior.html
@@ -165,7 +165,7 @@
 			var index = elems.indexOf(elem);
 			if (index === elems.length - 1) {
 				if (this.arrowKeyFocusablesNoWrap) {
-					return elem;
+					return;
 				}
 				return elems[0];
 			}
@@ -179,7 +179,7 @@
 			var index = elems.indexOf(elem);
 			if (index === 0) {
 				if (this.arrowKeyFocusablesNoWrap) {
-					return elem;
+					return;
 				}
 				return elems[elems.length - 1];
 			}

--- a/test/focusable-arrowkeys-behavior.html
+++ b/test/focusable-arrowkeys-behavior.html
@@ -66,6 +66,9 @@
 							simpleFixture.arrowKeyFocusablesOnBeforeFocus = function(elem) {
 								return new Promise(function(resolve) {
 									expect(elem).to.equal(focusables[keyInteractions[i].endIndex]);
+									if (focusables[keyInteractions[i].startIndex] === focusables[keyInteractions[i].endIndex]) {
+										done();
+									}
 									resolve();
 								})
 							};
@@ -120,6 +123,23 @@
 						{ name: 'focuses on last focusable when Up arrow key is pressed on first focusable', startIndex: 0, endIndex: 4, keyCode: 38 },
 						{ name: 'focuses on first focusable when Home key is pressed', startIndex: 2, endIndex: 0, keyCode: 36 },
 						{ name: 'focuses on last focusable when End key is pressed', startIndex: 2, endIndex: 4, keyCode: 35 }
+					]);
+
+				});
+
+				describe('nowrap - up-down-left-right', function() {
+
+					beforeEach(function(done) {
+						simpleFixture.arrowKeyFocusablesDirection = 'updownleftright';
+						simpleFixture.arrowKeyFocusablesNoWrap = true;
+						done();
+					});
+
+					testKeyInteractions([
+						{ name: 'does not focus on last focusable when Left arrow key is pressed on first focusable', startIndex: 0, endIndex: 0, keyCode: 37 },
+						{ name: 'does not focus on last focusable when Up arrow key is pressed on first focusable', startIndex: 0, endIndex: 0, keyCode: 38 },
+						{ name: 'does not focus on first focusable when Right arrow key is pressed on last focusable', startIndex: 4, endIndex: 4, keyCode: 39 },
+						{ name: 'does not focus on first focusable when Down arrow key is pressed on last focusable', startIndex: 4, endIndex: 4, keyCode: 40 }
 					]);
 
 				});

--- a/test/focusable-arrowkeys-behavior.html
+++ b/test/focusable-arrowkeys-behavior.html
@@ -66,9 +66,6 @@
 							simpleFixture.arrowKeyFocusablesOnBeforeFocus = function(elem) {
 								return new Promise(function(resolve) {
 									expect(elem).to.equal(focusables[keyInteractions[i].endIndex]);
-									if (focusables[keyInteractions[i].startIndex] === focusables[keyInteractions[i].endIndex]) {
-										done();
-									}
 									resolve();
 								})
 							};
@@ -135,11 +132,30 @@
 						done();
 					});
 
-					testKeyInteractions([
-						{ name: 'does not focus on last focusable when Left arrow key is pressed on first focusable', startIndex: 0, endIndex: 0, keyCode: 37 },
-						{ name: 'does not focus on last focusable when Up arrow key is pressed on first focusable', startIndex: 0, endIndex: 0, keyCode: 38 },
-						{ name: 'does not focus on first focusable when Right arrow key is pressed on last focusable', startIndex: 4, endIndex: 4, keyCode: 39 },
-						{ name: 'does not focus on first focusable when Down arrow key is pressed on last focusable', startIndex: 4, endIndex: 4, keyCode: 40 }
+					var testNoWrap = function(keyInteractions) {
+						for (var i=0; i<keyInteractions.length; i++) {
+
+							(function(i) {
+
+								it(keyInteractions[i].name, function(done) {
+									focusables[keyInteractions[i].startIndex].focus();
+									MockInteractions.keyDownOn(focusables[[keyInteractions[i].startIndex]], keyInteractions[i].keyCode);
+
+									Polymer.RenderStatus.afterNextRender(simpleFixture, function() {
+										expect(D2L.Dom.Focus.getComposedActiveElement()).to.equal(focusables[keyInteractions[i].startIndex]);
+										done();
+									});
+								});
+
+							}(i));
+						}
+					}
+
+					testNoWrap([
+						{ name: 'does not focus on last focusable when Left arrow key is pressed on first focusable', startIndex: 0, keyCode: 37 },
+						{ name: 'does not focus on last focusable when Up arrow key is pressed on first focusable', startIndex: 0, keyCode: 38 },
+						{ name: 'does not focus on first focusable when Right arrow key is pressed on last focusable', startIndex: 4, keyCode: 39 },
+						{ name: 'does not focus on first focusable when Down arrow key is pressed on last focusable', startIndex: 4, keyCode: 40 }
 					]);
 
 				});


### PR DESCRIPTION
…havior

I'm looking to add these as options to the `arrowkeys-behavior` to address some comments from Colin regarding `multi-select` - In particular:
1.  Up/Down key behaviour should also focus previous/next (respectively)
2.  If focus is on the first/last element, we do not want to wrap back to the last/first element