### PR TITLE
Update visible-on-ancestor-behavior for touch devices

### DIFF
--- a/d2l-visible-on-ancestor-behavior.html
+++ b/d2l-visible-on-ancestor-behavior.html
@@ -15,6 +15,16 @@
 				opacity: 0 !important;
 				transform: translateY(-10px) !important;
 			}
+			@media only screen and (hover: none), only screen and (-moz-touch-enabled: 1) {
+				:host([d2l-visible-on-ancestor-hide]) {
+					opacity: 1 !important;
+					transform: translateY(0px) !important;
+				}
+				:host([d2l-visible-on-ancestor-no-hover-hide]) {
+					opacity: 0 !important;
+					transform: translateY(-10px) !important;
+				}
+			}
 		</style>
 	</template>
 </dom-module>

--- a/d2l-visible-on-ancestor-behavior.html
+++ b/d2l-visible-on-ancestor-behavior.html
@@ -20,7 +20,7 @@
 					opacity: 1 !important;
 					transform: translateY(0px) !important;
 				}
-				:host([d2l-visible-on-ancestor-no-hover-hide]) {
+				:host([d2l-visible-on-ancestor-hide][d2l-visible-on-ancestor-no-hover-hide]) {
 					opacity: 0 !important;
 					transform: translateY(-10px) !important;
 				}


### PR DESCRIPTION
When device does not support hover, always show visible on ancestor items unless indicated by `d2l-visible-on-ancestor-no-hover-hide`.