### PR TITLE
Removed none in style.display (not supported by IE11), replaced by em…

### DIFF
--- a/d2l-dom-expand-collapse.html
+++ b/d2l-dom-expand-collapse.html
@@ -31,7 +31,7 @@
 					node.style.overflow = 'hidden';
 					node.style.transition = '';
 					node.style.height = '0px';
-					node.style.display = node.getAttribute('data-d2l-ec-display');
+					node.style.display = node.getAttribute('data-d2l-ec-display') ? !node.getAttribute('data-d2l-ec-display') : '';
 					node.removeAttribute('data-d2l-ec-display');
 					if (node.classList.contains('d2l-hidden')) node.classList.remove('d2l-hidden');
 
@@ -58,7 +58,7 @@
 				var transitionEnd = function() {
 					node.removeEventListener('transitionend', transitionEnd);
 					fastdom.mutate(function() {
-						node.style.display = '';
+						node.style.display = 'none';
 						resolve();
 					});
 				};

--- a/d2l-dom-expand-collapse.html
+++ b/d2l-dom-expand-collapse.html
@@ -31,7 +31,7 @@
 					node.style.overflow = 'hidden';
 					node.style.transition = '';
 					node.style.height = '0px';
-					node.style.display = node.getAttribute('data-d2l-ec-display') ? !node.getAttribute('data-d2l-ec-display') : '';
+					node.style.display = node.getAttribute('data-d2l-ec-display') ? node.getAttribute('data-d2l-ec-display') : '';
 					node.removeAttribute('data-d2l-ec-display');
 					if (node.classList.contains('d2l-hidden')) node.classList.remove('d2l-hidden');
 

--- a/d2l-dom-expand-collapse.html
+++ b/d2l-dom-expand-collapse.html
@@ -58,7 +58,7 @@
 				var transitionEnd = function() {
 					node.removeEventListener('transitionend', transitionEnd);
 					fastdom.mutate(function() {
-						node.style.display = 'none';
+						node.style.display = '';
 						resolve();
 					});
 				};


### PR DESCRIPTION
DE31446. Removed none in style.display (not supported by IE11), replaced by em…
style.dislay = 'none' was causing the bug in IE11. I found out that style.display = 'none' attribute was not supported by IE11. I replaced it with the empty quotes, which reset the display to default. I tested it on Firefox, IE11, Chrome, and Edge through the Demo page as well as on my local instance. 