### PR TITLE
US105979 - add browser consistent version of offsetParent

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ D2L.Dom.getComposedParent(node);
 
 // returns true/false whether the specified ancestorNode is an ancestor of node
 D2L.Dom.isComposedAncestor(ancestorNode, node);
+
+// browser consistent implementation of HTMLElement.offsetParent
+D2L.Dom.getOffsetParent(node);
 ```
 
 **D2L.Dom.Focus**

--- a/d2l-dom.js
+++ b/d2l-dom.js
@@ -89,7 +89,7 @@ D2L.Dom = {
 
 		let currentNode = this.getComposedParent(node);
 		while (currentNode) {
-			if (currentNode instanceof ShadowRoot ) {
+			if (currentNode instanceof ShadowRoot) {
 				currentNode = this.getComposedParent(currentNode);
 			}
 			const position = window.getComputedStyle(currentNode).position;

--- a/d2l-dom.js
+++ b/d2l-dom.js
@@ -72,6 +72,40 @@ D2L.Dom = {
 		return this.findComposedAncestor(node, function(node) {
 			return (node === ancestorNode);
 		}) !== null;
+	},
+
+	getOffsetParent: function(node) {
+		if (!window.ShadowRoot) {
+			return node.offsetParent;
+		}
+
+		if (
+			!this.getComposedParent(node) ||
+			node.tagName === 'BODY' ||
+			window.getComputedStyle(node).position === 'fixed'
+		) {
+			return null;
+		}
+
+		let currentNode = this.getComposedParent(node);
+		while (currentNode) {
+			if (currentNode instanceof ShadowRoot ) {
+				currentNode = this.getComposedParent(currentNode);
+			}
+			const position = window.getComputedStyle(currentNode).position;
+			const tagName = currentNode.tagName;
+
+			if (
+				(position && position !== 'static') ||
+				tagName === 'BODY' ||
+				position === 'static' && (tagName === 'TD' || tagName === 'TH' || tagName === 'TABLE')
+			) {
+				return currentNode;
+			}
+			currentNode = this.getComposedParent(currentNode);
+		}
+
+		return null;
 	}
 
 };

--- a/test/dom-offset-parent.html
+++ b/test/dom-offset-parent.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-dom get-offset-parent tests</title>
+		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="../../wct-browser-legacy/browser.js"></script>
+		<script type="module" src="../d2l-dom.js"></script>
+		<style>
+			.relative {
+				position: relative;
+			}
+			.static {
+				position: static;
+			}
+		</style>
+	</head>
+	<body>
+		<test-fixture id="direct-parent">
+			<template><div>
+					<div class="relative expected">
+						<div class="child"></div>
+					</div>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="indirect-parent">
+			<template><div>
+					<div class="relative expected">
+						<div>
+							<div class="child"></div>
+						</div>
+					</div>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="td">
+			<template><div>
+				<table>
+					<td class="static expected">
+						<div class="child"></div>
+					</td>
+				</table>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="th">
+			<template><div>
+				<table>
+					<th class="static expected">
+						<div class="child"></div>
+					</th>
+				</table>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="table">
+			<template><div>
+				<table class="static expected">
+					<tbody class="child"></tbody>
+				</table>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-simple">
+			<template><div>
+				<test-wrapper wrapper-id="expected">
+					<div class="child"></div>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-inside">
+			<template><div>
+				<test-wrapper>
+					<div class="relative expected">
+						<div class="child"></div>
+					<div>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-nested">
+			<template><div>
+				<test-wrapper>
+					<test-wrapper wrapper-id="expected">
+						<div class="child"></div>
+					</test-wrapper>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-passthrough">
+			<template><div>
+				<div class="relative expected">
+					<test-wrapper>
+						<div class="child"></div>
+					</test-wrapper>
+				<div>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-is-parent">
+			<template><div>
+				<test-wrapper class="relative expected">
+					<div class="child"></div>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="nested-wrapper-is-parent">
+			<template><div>
+				<test-wrapper class="relative expected">
+					<test-wrapper>
+						<div class="child"></div>
+					</test-wrapper>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<div id="fixed" style="position: fixed;">
+		</div>
+
+		<div id="bodyIsParent">
+		</div>
+
+		<script type="module">
+describe('d2l-dom', function() {
+	describe('getOffsetParent', function() {
+		[
+			'direct-parent',
+			'indirect-parent',
+			'td',
+			'th',
+			'table',
+			'wrapper-inside',
+			'wrapper-passthrough',
+			'wrapper-is-parent',
+			'nested-wrapper-is-parent'
+		].forEach(fixtureName => {
+			it(fixtureName, function() {
+				const fixt = fixture(fixtureName);
+				const child = fixt.querySelector('.child');
+				const expected = fixt.querySelector('.expected');
+				expect(D2L.Dom.getOffsetParent(child)).to.equal(expected);
+			});
+		});
+
+		it('wrapper-simple', function() {
+			const fixt = fixture('wrapper-simple');
+			const child = fixt.querySelector('.child');
+			expect(D2L.Dom.getOffsetParent(child).id).to.equal('expected');
+		});
+
+		it('wrapper-nested', function() {
+			const fixt = fixture('wrapper-nested');
+			const child = fixt.querySelector('.child');
+			expect(D2L.Dom.getOffsetParent(child).id).to.equal('expected');
+		});
+
+		it('fallback-when-shadowroot-undefined', function() {
+			const tempShadowRoot = window.ShadowRoot;
+			window.ShadowRoot = false;
+			const child = {
+				offsetParent: 'this is the offsetParent'
+			};
+			expect(D2L.Dom.getOffsetParent(child)).to.equal(child.offsetParent);
+			window.ShadowRoot = tempShadowRoot;
+		});
+
+		it('body', function() {
+			const body = document.querySelector('body');
+			expect(D2L.Dom.getOffsetParent(body)).to.equal(null);
+		});
+
+		it('orphan', function() {
+			const child = document.createElement('div');
+			expect(D2L.Dom.getOffsetParent(child)).to.equal(null);
+		});
+
+		it('orphan-with-extra-steps', function() {
+			const grandparent = document.createElement('div');
+			const parent = document.createElement('div');
+			const child = document.createElement('div');
+			grandparent.appendChild(parent);
+			parent.appendChild(child);
+			expect(D2L.Dom.getOffsetParent(child)).to.equal(null);
+		});
+
+		it('fixed', function() {
+			const fixed = document.querySelector('#fixed');
+			expect(D2L.Dom.getOffsetParent(fixed)).to.equal(null);
+		});
+
+		it('body-is-parent', function() {
+			const fixed = document.querySelector('#bodyIsParent');
+			const body = document.querySelector('body');
+			expect(D2L.Dom.getOffsetParent(fixed)).to.equal(body);
+		});
+	});
+});
+		</script>
+		<script type="module">
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+
+class TestWrapper extends PolymerElement {
+	static get template() {
+		return html`
+			<style>
+				#expected {
+					position: relative;
+				}
+			</style>
+			<div id=[[wrapperId]]>
+				<slot></slot>
+			</div>
+		`;
+	}
+	static get properties() {
+		return {
+			wrapperId: {
+				type: String,
+				value: 'notExpected'
+			}
+		};
+	}
+}
+
+window.customElements.define('test-wrapper', TestWrapper);
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,8 @@
 			'focusable-arrowkeys-behavior.html',
 			'focusable-behavior.html',
 			'id.html',
-			'visible-on-ancestor-behavior.html'
+			'visible-on-ancestor-behavior.html',
+			'dom-offset-parent.html'
 		];
 
 		for (var i = 0; i < tests.length; i++) {


### PR DESCRIPTION
Continuation of https://github.com/BrightspaceUI/tooltip/pull/45

Putting `offsetParent` in the correct place. I also changed it to use `getComposedParent`.

I started rewriting the tests to match the style of the other d2l-dom tests but was finding it not worth it (made the file messy and hard to read). So I just imported my previous written test file as a standalone and left the current tests as-is.