### PR TITLE
fix error when node is a DocumentFragment but not ShadowRoot

### DIFF
--- a/d2l-dom.js
+++ b/d2l-dom.js
@@ -93,13 +93,14 @@ D2L.Dom = {
 				currentNode = this.getComposedParent(currentNode);
 			} else if (currentNode instanceof DocumentFragment) {
 				return null;
+			} else if (currentNode.tagName === 'BODY') {
+				return currentNode;
 			}
 			const position = window.getComputedStyle(currentNode).position;
 			const tagName = currentNode.tagName;
 
 			if (
 				(position && position !== 'static') ||
-				tagName === 'BODY' ||
 				position === 'static' && (tagName === 'TD' || tagName === 'TH' || tagName === 'TABLE')
 			) {
 				return currentNode;

--- a/d2l-dom.js
+++ b/d2l-dom.js
@@ -91,6 +91,8 @@ D2L.Dom = {
 		while (currentNode) {
 			if (currentNode instanceof ShadowRoot) {
 				currentNode = this.getComposedParent(currentNode);
+			} else if (currentNode instanceof DocumentFragment) {
+				return null;
 			}
 			const position = window.getComputedStyle(currentNode).position;
 			const tagName = currentNode.tagName;


### PR DESCRIPTION
We were getting this error:
![image](https://user-images.githubusercontent.com/1471557/57895233-7718f180-77ff-11e9-990e-f909fdedd53f.png)

when the composedParent of a tooltip element was a DocumentFragment but not a ShadowRoot, so adding this check eliminates the error.