### PR TITLE
Update getComposedActiveElement to check for null [increment patch]

### DIFF
--- a/d2l-dom-focus.js
+++ b/d2l-dom-focus.js
@@ -19,6 +19,7 @@ var Focus = {
 
 	getComposedActiveElement: function() {
 		var node = document.activeElement;
+		if (!node) return null;
 		while (node.shadowRoot) {
 			if (node.shadowRoot.activeElement) {
 				node = node.shadowRoot.activeElement;


### PR DESCRIPTION
This PR checks for node before trying to access shadowRoot, since it is possible for the document's activeElement to be null.