### PR TITLE
Use core helpers that have been moved. [increment patch]

### DIFF
--- a/d2l-dom.js
+++ b/d2l-dom.js
@@ -1,78 +1,17 @@
+import * as dom from '@brightspace-ui/core/helpers/dom.js';
+
 window.D2L = window.D2L || {};
 
 /** @polymerBehavior */
 D2L.Dom = {
 
-	findComposedAncestor: function(node, predicate) {
-		while (node) {
-			if (predicate(node) === true) {
-				return node;
-			}
-			node = this.getComposedParent(node);
-		}
-		return null;
-	},
+	findComposedAncestor: dom.findComposedAncestor,
 
-	getComposedChildren: function(node) {
+	getComposedChildren: dom.getComposedChildren,
 
-		if (!node) {
-			return null;
-		}
-		if (node.nodeType !== 1 && node.nodeType !== 9 && node.nodeType !== 11) {
-			return null;
-		}
+	getComposedParent: dom.getComposedParent,
 
-		var nodes, children = [];
-
-		if (node.tagName === 'CONTENT') {
-			nodes = node.getDistributedNodes();
-		} else if (node.tagName === 'SLOT') {
-			nodes = node.assignedNodes({flatten: true});
-		} else {
-			if (node.shadowRoot) {
-				node = node.shadowRoot;
-			}
-			nodes = node.children || node.childNodes;
-		}
-
-		for (var i = 0; i < nodes.length; i++) {
-			if (nodes[i].nodeType === 1) {
-				children.push(nodes[i]);
-			}
-		}
-
-		return children;
-
-	},
-
-	getComposedParent: function(node) {
-
-		if (node.getDestinationInsertionPoints) {
-			var insertionPoints = node.getDestinationInsertionPoints();
-			if (insertionPoints && insertionPoints.length > 0) {
-				return insertionPoints[0];
-			}
-		}
-
-		if (node.assignedSlot) {
-			return node.assignedSlot;
-		}
-
-		if (node.parentNode) {
-			return node.parentNode;
-		} else if (node.host) {
-			return node.host;
-		}
-
-		return null;
-
-	},
-
-	isComposedAncestor: function(ancestorNode, node) {
-		return this.findComposedAncestor(node, function(node) {
-			return (node === ancestorNode);
-		}) !== null;
-	},
+	isComposedAncestor: dom.isComposedAncestor,
 
 	getOffsetParent: function(node) {
 		if (!window.ShadowRoot) {

--- a/d2l-id.js
+++ b/d2l-id.js
@@ -1,14 +1,8 @@
+import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
+
 var Id = {
 
-	getUniqueId: function() {
-
-		if (window.D2L.Id._unique_index === undefined) {
-			window.D2L.Id._unique_index = 0;
-		}
-		window.D2L.Id._unique_index++;
-		return 'd2l-uid-' + window.D2L.Id._unique_index;
-
-	}
+	getUniqueId: getUniqueId
 
 };
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
-    "fastdom": "^1.0.8",
-    "@polymer/polymer": "^3.0.0"
+    "@brightspace-ui/core": "^1",
+    "@polymer/polymer": "^3.0.0",
+    "fastdom": "^1.0.8"
   }
 }


### PR DESCRIPTION
This PR imports the helper functions from core that have been moved.

The associated unit-tests sort of become redundant with this change.  For the moment, I left them in place to show they all still pass (which they should since the underlying logic is identical).