### PR TITLE
adding to D2L.Dom, not replacing it

### DIFF
--- a/d2l-dom.js
+++ b/d2l-dom.js
@@ -6,53 +6,44 @@ import {
 } from '@brightspace-ui/core/helpers/dom.js';
 
 window.D2L = window.D2L || {};
+window.D2L.Dom = window.D2L.Dom || {};
+window.D2L.Dom.findComposedAncestor = findComposedAncestor;
+window.D2L.Dom.getComposedChildren = getComposedChildren;
+window.D2L.Dom.getComposedParent = getComposedParent;
+window.D2L.Dom.isComposedAncestor = isComposedAncestor;
+window.D2L.Dom.getOffsetParent = function(node) {
+	if (!window.ShadowRoot) {
+		return node.offsetParent;
+	}
 
-/** @polymerBehavior */
-D2L.Dom = {
-
-	findComposedAncestor: findComposedAncestor,
-
-	getComposedChildren: getComposedChildren,
-
-	getComposedParent: getComposedParent,
-
-	isComposedAncestor: isComposedAncestor,
-
-	getOffsetParent: function(node) {
-		if (!window.ShadowRoot) {
-			return node.offsetParent;
-		}
-
-		if (
-			!this.getComposedParent(node) ||
-			node.tagName === 'BODY' ||
-			window.getComputedStyle(node).position === 'fixed'
-		) {
-			return null;
-		}
-
-		let currentNode = this.getComposedParent(node);
-		while (currentNode) {
-			if (currentNode instanceof ShadowRoot) {
-				currentNode = this.getComposedParent(currentNode);
-			} else if (currentNode instanceof DocumentFragment) {
-				return null;
-			} else if (currentNode.tagName === 'BODY') {
-				return currentNode;
-			}
-			const position = window.getComputedStyle(currentNode).position;
-			const tagName = currentNode.tagName;
-
-			if (
-				(position && position !== 'static') ||
-				position === 'static' && (tagName === 'TD' || tagName === 'TH' || tagName === 'TABLE')
-			) {
-				return currentNode;
-			}
-			currentNode = this.getComposedParent(currentNode);
-		}
-
+	if (
+		!this.getComposedParent(node) ||
+		node.tagName === 'BODY' ||
+		window.getComputedStyle(node).position === 'fixed'
+	) {
 		return null;
 	}
 
+	let currentNode = this.getComposedParent(node);
+	while (currentNode) {
+		if (currentNode instanceof ShadowRoot) {
+			currentNode = this.getComposedParent(currentNode);
+		} else if (currentNode instanceof DocumentFragment) {
+			return null;
+		} else if (currentNode.tagName === 'BODY') {
+			return currentNode;
+		}
+		const position = window.getComputedStyle(currentNode).position;
+		const tagName = currentNode.tagName;
+
+		if (
+			(position && position !== 'static') ||
+			position === 'static' && (tagName === 'TD' || tagName === 'TH' || tagName === 'TABLE')
+		) {
+			return currentNode;
+		}
+		currentNode = this.getComposedParent(currentNode);
+	}
+
+	return null;
 };


### PR DESCRIPTION
This bug was exposed recently [when I removed expand/collapse](https://github.com/Brightspace/brightspace-integration/pull/2375/files) from every page. It was importing `d2l-dom.js` early, and then if `d2l-dom-focus.js` is imported later everything is fine. But if the order is reversed (as happened here), `d2l-dom.js` overwrites `D2L.Dom` and removes `D2L.Dom.Focus`.