### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "requestIdleCallback.js"
   ],
   "publishConfig": {
+    "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "requestIdleCallback.js"
   ],
   "publishConfig": {
-    "access": "public"
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "@brightspace-ui/core": "^3",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564